### PR TITLE
security: upgrade Go to 1.25.11 and buger/jsonparser to 1.1.2

### DIFF
--- a/go/go.mod
+++ b/go/go.mod
@@ -1,6 +1,6 @@
 module azan-agent
 
-go 1.25.0
+go 1.25.11
 
 require (
 	github.com/BurntSushi/toml v1.3.2
@@ -12,14 +12,14 @@ require (
 	github.com/kardianos/service v1.2.4
 	github.com/robfig/cron/v3 v3.0.1
 	github.com/vishen/go-chromecast v0.3.3
-	golang.org/x/mod v0.37.0
 	golang.org/x/crypto v0.53.0
+	golang.org/x/mod v0.37.0
 	golang.org/x/sys v0.46.0
 	golang.org/x/term v0.44.0
 )
 
 require (
-	github.com/buger/jsonparser v1.1.1 // indirect
+	github.com/buger/jsonparser v1.1.2 // indirect
 	github.com/cenkalti/backoff v2.2.1+incompatible // indirect
 	github.com/ebitengine/purego v0.9.0 // indirect
 	github.com/getlantern/context v0.0.0-20190109183933-c447772a6520 // indirect

--- a/go/go.sum
+++ b/go/go.sum
@@ -1,7 +1,7 @@
 github.com/BurntSushi/toml v1.3.2 h1:o7IhLm0Msx3BaB+n3Ag7L8EVlByGnpq14C4YWiu/gL8=
 github.com/BurntSushi/toml v1.3.2/go.mod h1:CxXYINrC8qIiEnFrOxCa7Jy5BFHlXnUU2pbicEuybxQ=
-github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
-github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
+github.com/buger/jsonparser v1.1.2 h1:frqHqw7otoVbk5M8LlE/L7HTnIq2v9RX6EJ48i9AxJk=
+github.com/buger/jsonparser v1.1.2/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff v2.2.1+incompatible h1:tNowT99t7UNflLxfYYSlKYsBpXdEet03Pg2g16Swow4=
 github.com/cenkalti/backoff v2.2.1+incompatible/go.mod h1:90ReRw6GdpyfrHakVjL/QHaoyV4aDUVVkXQJJJ3NXXM=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=


### PR DESCRIPTION
Fixes 17 CVEs found by trivy scan:
- CRITICAL CVE-2025-68121: TLS session resumption cert validation (stdlib)
- 15x HIGH: DoS via net/url, crypto/tls, crypto/x509, net, net/http (stdlib)
- HIGH CVE-2026-32285: DoS in buger/jsonparser (fixed in v1.1.2)